### PR TITLE
PoC: improve error handling

### DIFF
--- a/server/src/services/analytic_service/analytic_unit/threshold_analytic_unit.rs
+++ b/server/src/services/analytic_service/analytic_unit/threshold_analytic_unit.rs
@@ -21,8 +21,8 @@ impl ThresholdAnalyticUnit {
 
 #[async_trait]
 impl AnalyticUnit for ThresholdAnalyticUnit {
-    async fn learn(&mut self, _ms: MetricService, _ss: SegmentsService) -> LearningResult {
-        return LearningResult::Finished;
+    async fn learn(&mut self, _ms: MetricService, _ss: SegmentsService) -> anyhow::Result<LearningResult> {
+        return Ok(LearningResult::Finished);
     }
 
     fn set_config(&mut self, config: AnalyticUnitConfig) {

--- a/server/src/services/analytic_service/analytic_unit/types.rs
+++ b/server/src/services/analytic_service/analytic_unit/types.rs
@@ -125,13 +125,12 @@ impl AnalyticUnitConfig {
 
 pub enum LearningResult {
     Finished,
-    FinishedEmpty,
-    DatasourceError,
+    FinishedEmpty
 }
 
 #[async_trait]
 pub trait AnalyticUnit {
-    async fn learn(&mut self, ms: MetricService, ss: SegmentsService) -> LearningResult;
+    async fn learn(&mut self, ms: MetricService, ss: SegmentsService) -> anyhow::Result<LearningResult>;
     async fn detect(
         &self,
         ms: MetricService,

--- a/server/src/services/analytic_service/types.rs
+++ b/server/src/services/analytic_service/types.rs
@@ -45,8 +45,7 @@ impl Default for LearningTrain {
 pub enum ResponseType {
     LearningStarted,
     LearningFinished(Box<dyn AnalyticUnit + Send + Sync>),
-    LearningFinishedEmpty,
-    LearningDatasourceError,
+    LearningFinishedEmpty
 }
 
 impl fmt::Debug for ResponseType {
@@ -117,5 +116,5 @@ pub enum RequestType {
 pub enum AnalyticServiceMessage {
     // Status,
     Request(RequestType),
-    Response(ResponseType), // Detect { from: u64, to: u64 },
+    Response(anyhow::Result<ResponseType>), // Detect { from: u64, to: u64 },
 }


### PR DESCRIPTION
Related issue: #42 

This PR updates `.learn()` `AnalyticUnit`'s method to return error instead of panicking. It'd be great to do the same for other methods

Changes:
- analytic units: 
  - change `.learn()` return type from `LearningResult` to `anyhow::Result<LearningResult>`
  - get rid of `unwrap`s in `.learn()` mostly
- remove `DatasourceError` from `LearningResult`
- remove `LearningDatasourceError` from `ResponseType` (`Err` is used instead)