### PR TITLE
Bucket detection window for pattern analytic unit #83

### DIFF
--- a/server/src/services/analytic_service/analytic_unit/pattern_analytic_unit.rs
+++ b/server/src/services/analytic_service/analytic_unit/pattern_analytic_unit.rs
@@ -220,8 +220,8 @@ impl AnalyticUnit for PatternAnalyticUnit {
         return self.id.to_owned();
     }
     fn get_detection_window(&self) -> u64 {
-        // TODO: return window based on real petterns info
-        return DETECTION_STEP;
+        let lr = self.learning_results.as_ref().unwrap();
+        return lr.avg_pattern_length as u64;
     }
     fn set_config(&mut self, config: AnalyticUnitConfig) {
         if let AnalyticUnitConfig::Pattern(cfg) = config {

--- a/server/src/services/analytic_service/detection_runner.rs
+++ b/server/src/services/analytic_service/detection_runner.rs
@@ -48,7 +48,6 @@ impl DetectionRunner {
                 // TODO: parse detections to webhooks
                 // TODO: define window for detection
                 // TODO: handle case when detection is in the end and continues after "now"
-                // TODO: update t_from / t_to
 
                 let window_size = au.as_ref().read().await.get_detection_window();
                 let detection_step = ms.get_detection_step();

--- a/server/src/services/analytic_service/detection_runner.rs
+++ b/server/src/services/analytic_service/detection_runner.rs
@@ -49,6 +49,7 @@ impl DetectionRunner {
                 // TODO: parse detections to webhooks
                 // TODO: define window for detection
                 // TODO: handle case when detection is in the end and continues after "now"
+                // TODO: update t_from / t_to
                 let window_size = au.as_ref().read().await.get_detection_window();
                 let mut t_from = from - window_size;
                 let mut t_to = from;
@@ -71,7 +72,6 @@ impl DetectionRunner {
                         println!("detection: {} {}", d.0, d.1);
                     }
 
-                    // TODO: run detection periodically
                     // TODO: set info about detections to tx
 
                     match tx

--- a/server/src/services/analytic_service/detection_runner.rs
+++ b/server/src/services/analytic_service/detection_runner.rs
@@ -7,7 +7,6 @@ use crate::services::metric_service::MetricService;
 use super::types::{AnalyticServiceMessage, AnalyticUnitRF, DetectionRunnerConfig, ResponseType};
 use tokio::time::{sleep, Duration};
 
-const DETECTION_STEP: u64 = 10;
 
 pub struct DetectionRunner {
     metric_service: MetricService,
@@ -50,7 +49,9 @@ impl DetectionRunner {
                 // TODO: define window for detection
                 // TODO: handle case when detection is in the end and continues after "now"
                 // TODO: update t_from / t_to
+
                 let window_size = au.as_ref().read().await.get_detection_window();
+                let detection_step = ms.get_detection_step();
                 let mut t_from = from - window_size;
                 let mut t_to = from;
 
@@ -88,6 +89,8 @@ impl DetectionRunner {
                     }
 
                     sleep(Duration::from_secs(cfg.interval)).await;
+                    t_from += detection_step;
+                    t_to += detection_step;
                 }
             }
         }));

--- a/server/src/services/metric_service.rs
+++ b/server/src/services/metric_service.rs
@@ -32,4 +32,11 @@ impl MetricService {
         }
         return Ok(mr);
     }
+
+    // TODO: it a hack for DetectionRunner: it should vary for different analytic units
+    //       and it's config         
+    pub fn get_detection_step(&self) -> u64 {
+        return 10;
+    }
+
 }


### PR DESCRIPTION
Closes https://github.com/hastic/hastic/issues/83

## Changes
* MetricService now has `get_detection_step` method which return `10` -- it's a hack
* `PatternAnalyticUnit` returns `avg_pattern_length` in `get_detection_window` -- it's also not 100% right cuz there used `unwrap` and formally learning results can be `None`

## Notes
This PR doesn't really introduce bucket and query from `metrics_service` used to get data for detection