### PR TITLE
env variables configuration #55

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -97,7 +97,6 @@ fn parse_env(key: &str) -> Option<String> {
 
     if key.starts_with(PREFIX) {
         let key = &key[PREFIX.len()..];
-
         Some(key.to_lowercase().replace("__", ".").replace("_", "-"))
     } else {
         None


### PR DESCRIPTION
Closes #55 

This PR makes it possible to configure `hastic` using environment variables

**Changes**:
- remove `config::Environment::with_prefix("HASTIC")` usage because it doesn't support nested keys, e.g. `alerting.type`
- use `update_from_env` instead (a function copied from here: https://github.com/rust-lang/mdBook/blob/f3e5fce6bf5e290c713f4015947dc0f0ad172d20/src/config.rs#L132), it replaces `__` in the variables with `.`

**Configuration example**:
```bash
HASTIC_PORT=8000 \
HASTIC_PROMETHEUS__URL="http://localhost:9090" \
HASTIC_PROMETHEUS__URL="rate(go_memstats_alloc_bytes_total[5m])" \
cargo run
```

**TODO**: we also need to add configuration docs to the readme, I'll do it in a separate PR 
