### PR TITLE
Env vars docs #90

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Hastic can be configured using config-file or environment variables.
 At first, choose which datasource you'll be using: `prometheus` or `influx`. Only one can be used at a time.
 
 #### Config-file
-- copy the config example to the release directory
+- copy the config example to the release directory:
 ```bash
 cp config.example.toml release/config.toml
 ```
-- edit the config file, e.g. using `nano`
+- edit the config file, e.g. using `nano`:
 ```bash
 nano release/config.toml
 ```
@@ -46,7 +46,7 @@ export HASTIC_PROMETHEUS__URL=http://localhost:9090
 export HASTIC_PROMETHEUS__QUERY=rate(go_memstats_alloc_bytes_total[5m])
 ```
 
-or specifing them in a run command (they'll be actual only for one run)
+or specifing them in a run command (they'll be actual only for one run):
 ```bash
 HASTIC_PORT=8000 HASTIC_PROMETHEUS__URL=http://localhost:9090 HASTIC_PROMETHEUS__QUERY=rate(go_memstats_alloc_bytes_total[5m]) ./release/hastic
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,42 @@ instance for getting metrics.
 make
 ```
 
+### Configure
+Hastic can be configured using config-file or environment variables.
+
+At first, choose which datasource you'll be using: `prometheus` or `influx`. Only one can be used at a time.
+
+#### Config-file
+- copy the config example to the release directory
+```bash
+cp config.example.toml release/config.toml
+```
+- edit the config file, e.g. using `nano`
+```bash
+nano release/config.toml
+```
+
+#### Environment variables
+All config fields are also available as environment variables with `HASTIC_` prefix
+
+Variable name structure:
+- for high-level fields: `HASTIC_<field_name>`, e.g. `HASTIC_PORT`
+- for nested fields: `HASTIC_<category_name>__<field_name>`, e.g. `HASTIC_PROMETHEUS__URL`
+
+Environment variables can be set either by exporting them (they'll be actual until a bash-session is closed):
+```bash
+export HASTIC_PORT=8000
+export HASTIC_PROMETHEUS__URL=http://localhost:9090
+export HASTIC_PROMETHEUS__QUERY=rate(go_memstats_alloc_bytes_total[5m])
+```
+
+or specifing them in a run command (they'll be actual only for one run)
+```bash
+HASTIC_PORT=8000 HASTIC_PROMETHEUS__URL=http://localhost:9090 HASTIC_PROMETHEUS__QUERY=rate(go_memstats_alloc_bytes_total[5m]) ./release/hastic
+```
+
+### Run
+
 ```
 cd release
 ./hastic


### PR DESCRIPTION
Closes #90 

This PR adds `hastic` configuration documentation to the readme (including environment variables)